### PR TITLE
GPSがオフの場合でも現在位置取得待ちにならないように対応

### DIFF
--- a/lib/pages/map/map_page.dart
+++ b/lib/pages/map/map_page.dart
@@ -37,19 +37,7 @@ class _MapPageState extends State<MapPage> {
     if (_state == null) {
       _state = Provider.of<MapPageStore>(context, listen: false);
       _state!.setMapController(_mapController);
-      _state!.init().then((_) {
-        if (!_state!.locationRequested) {
-          _state!.requestLocationPermission().then((permission) {
-            if (permission == LocationPermissionResult.deniedForever) {
-              //return const Center(child: Text("位置情報の使用が拒否されています。"));
-              return;
-            }
-
-            // 位置情報の追跡を行う場合はここで現在地を求めると停止してしまうので、開始場所は別途検討する
-            _state!.updateLocation();
-          });
-        }
-      });
+      _state!.init();
     }
   }
 

--- a/lib/pages/map/map_page_store.dart
+++ b/lib/pages/map/map_page_store.dart
@@ -49,6 +49,25 @@ class MapPageStore extends ChangeNotifier {
     var user = _authService.getUser();
     //await _routeRepository.save(user, _strollRoute);
     _mapInfo = await _mapInfoRepository.fetchMapByName('cats');
+
+    if (!_locationRequested) {
+      var permission = await requestLocationPermission();
+      if (permission == LocationPermissionResult.deniedForever) {
+        //return const Center(child: Text("位置情報の使用が拒否されています。"));
+        // 現在位置は取得できないので、デフォルトの座標を取得する。
+        // 最初のスポットか、それがない場合は110-0001あたりにする
+        _position = null;
+        if (_mapInfo?.spots.entries.first != null) {
+          _position = _mapInfo?.spots.entries.first.value.point;
+        } else {
+          _position = Position(35.723605, 139.768156);
+        }
+        return;
+      }
+
+      // 位置情報の追跡を行う場合はここで現在地を求めると停止してしまうので、開始場所は別途検討する
+      updateLocation();
+    }
   }
 
   /// 位置情報の権限を確認、必要に応じて権限の取得を求める


### PR DESCRIPTION
## チケット
- #49 
## 対応内容・対応背景・妥協点
- アプリに対しGPSを許可しないユーザーでもスポットの閲覧や名前・写真の登録は出来るようにしたい
    - この後でお知らせ機能を追加する際も、特にGPSは必要がない

## やったこと
- GPSがオフの場合に現在位置取得待ちで止まらないように対応
    - 取得できない場合は最初のスポットか、スポットがない場合は110-0001付近の座標を基準にするように対応
