### PR TITLE
最終訪問日を記録できるように対応

### DIFF
--- a/lib/components/date_time_picker.dart
+++ b/lib/components/date_time_picker.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class DateTimePicker {
+  static Future<DateTime?> show(BuildContext context,
+      {DateTime? initialDate, DateTime? firstDate, DateTime? lastDate}) async {
+    initialDate ??= DateTime.now();
+    firstDate ??= DateTime.now();
+    lastDate ??= DateTime.now();
+    var datePart = await showDatePicker(
+        context: context,
+        initialDate: initialDate,
+        firstDate: firstDate,
+        lastDate: lastDate);
+
+    if (datePart == null) {
+      return null;
+    }
+
+    var timePart = await showTimePicker(
+        context: context, initialTime: TimeOfDay.fromDateTime(initialDate));
+
+    if (timePart == null) {
+      return null;
+    }
+
+    return DateTime(datePart.year, datePart.month, datePart.day, timePart.hour,
+        timePart.minute, 0);
+  }
+}

--- a/lib/domain/map_info.dart
+++ b/lib/domain/map_info.dart
@@ -21,13 +21,16 @@ class Spot {
 
   List<Photo> photos;
 
+  DateTime? lastVisited;
+
   Spot(this.title, this.point,
       {String? id,
       this.comment = "",
       DateTime? newDate,
       this.score = 1.0,
       this.userNameInfo,
-      List<Photo>? photos})
+      List<Photo>? photos,
+      this.lastVisited})
       : id = id ?? Ulid().toString(),
         date = newDate ?? DateTime.now(),
         photos = photos ?? [];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:strollog/lib/router/app_router.dart';
 import 'package:strollog/lib/router/router_state.dart';
 import 'package:strollog/pages/app_store.dart';
 import 'package:strollog/pages/map/map_page_store.dart';
+import 'package:strollog/pages/map/spot_detail_page_store.dart';
 import 'package:strollog/pages/map/spot_edit_page_store.dart';
 import 'package:strollog/pages/map/spot_create_page_store.dart';
 import 'package:strollog/pages/name_management/name_add_page_store.dart';
@@ -142,6 +143,9 @@ class _ApplicationState extends State<Application> {
                   Provider.of<AuthService>(_context, listen: false),
                   Provider.of<ImageLoaderPhoto>(_context, listen: false),
                 )),
+        ChangeNotifierProvider<SpotDetailPageStore>(
+            create: (_context) => SpotDetailPageStore(
+                Provider.of<MapInfoRepository>(_context, listen: false))),
         ChangeNotifierProvider<NameAddPageStore>(
             create: (_context) => NameAddPageStore(
                 Provider.of<NameRepository>(_context, listen: false),

--- a/lib/pages/map/map_page.dart
+++ b/lib/pages/map/map_page.dart
@@ -90,7 +90,7 @@ class _MapPageState extends State<MapPage> {
                     value: editFormStore),
                 Provider<ImageLoaderPhoto>.value(value: loader)
               ],
-              child: SpotDetailPage(spotId),
+              child: SpotDetailPage(store.mapInfo!.spots[spotId]!),
             ));
   }
 }

--- a/lib/pages/map/map_page_store.dart
+++ b/lib/pages/map/map_page_store.dart
@@ -57,7 +57,7 @@ class MapPageStore extends ChangeNotifier {
         // 現在位置は取得できないので、デフォルトの座標を取得する。
         // 最初のスポットか、それがない場合は110-0001あたりにする
         _position = null;
-        if (_mapInfo?.spots.entries.first != null) {
+        if (_mapInfo?.spots.entries.isNotEmpty ?? false) {
           _position = _mapInfo?.spots.entries.first.value.point;
         } else {
           _position = Position(35.723605, 139.768156);

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -41,9 +41,12 @@ class SpotDetailPage extends StatelessWidget {
             const SizedBox(width: 100, child: Text('タイトル')),
             Text(title),
           ]),
-          Row(children: [
+          Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
             const SizedBox(width: 100, child: Text('コメント')),
-            Text(comment),
+            Container(
+                child: Flexible(
+              child: Text(comment),
+            ))
           ]),
           Row(children: [
             const SizedBox(width: 100, child: Text('最終訪問日')),

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:strollog/components/image_thumbnail.dart';
 import 'package:strollog/components/ws_button.dart';
+import 'package:strollog/domain/map_info.dart';
 import 'package:strollog/domain/photo.dart';
 import 'package:strollog/lib/router/router_state.dart';
 import 'package:strollog/pages/map/map_page_store.dart';
@@ -42,6 +43,10 @@ class SpotDetailPage extends StatelessWidget {
           Row(children: [
             const SizedBox(width: 100, child: Text('コメント')),
             Text(comment),
+          ]),
+          Row(children: [
+            const SizedBox(width: 100, child: Text('最終訪問日')),
+            _buildLastVisited(context, store.mapInfo!.spots[_spotId]!),
           ]),
           FutureBuilder<List<DraftPhoto>>(
             future: _loadImages(context),
@@ -145,5 +150,20 @@ class SpotDetailPage extends StatelessWidget {
             children: photos)
       ]))
     ])));
+  }
+
+  Widget _buildLastVisited(BuildContext context, Spot spot) {
+    var dateString = spot.lastVisited != null
+        ? DateFormat('yyyy-MM-DD HH:mm').format(spot.lastVisited!)
+        : '未設定';
+
+    return InkWell(
+        child: Container(
+            padding: const EdgeInsets.only(top: 8, bottom: 8),
+            child: Row(children: [
+              Text(dateString),
+              const Icon(Icons.update, size: 32),
+            ])),
+        onTap: () {});
   }
 }

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -132,7 +132,9 @@ class SpotDetailPage extends StatelessWidget {
                 ]));
           });
     }).toList();
-    return Row(children: [
+    return Flexible(
+        child: SingleChildScrollView(
+            child: Row(children: [
       Expanded(
           child:
               Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
@@ -142,6 +144,6 @@ class SpotDetailPage extends StatelessWidget {
             crossAxisAlignment: WrapCrossAlignment.start,
             children: photos)
       ]))
-    ]);
+    ])));
   }
 }

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -17,15 +17,20 @@ import 'package:strollog/services/image_loader.dart';
 
 class SpotDetailPage extends StatelessWidget {
   final String _spotId;
+  Spot? spot;
 
-  const SpotDetailPage(this._spotId, {Key? key}) : super(key: key);
+  SpotDetailPage(this._spotId, {Key? key})
+      : spot = null,
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {
     var store = Provider.of<MapPageStore>(context);
-    var title = store.mapInfo!.spots[_spotId]!.title;
-    var comment = store.mapInfo!.spots[_spotId]!.comment;
-    var date = store.mapInfo!.spots[_spotId]!.date;
+    spot = store.mapInfo!.spots[_spotId];
+
+    var title = spot!.title;
+    var comment = spot!.comment;
+    var date = spot!.date;
     final dateString = DateFormat('yyyy-MM-dd HH:mm').format(date);
 
     return Container(
@@ -50,7 +55,7 @@ class SpotDetailPage extends StatelessWidget {
           ]),
           Row(children: [
             const SizedBox(width: 100, child: Text('最終訪問日')),
-            _buildLastVisited(context, store.mapInfo!.spots[_spotId]!),
+            _buildLastVisited(context, spot!),
           ]),
           FutureBuilder<List<DraftPhoto>>(
             future: _loadImages(context),
@@ -89,8 +94,7 @@ class SpotDetailPage extends StatelessWidget {
     final store = Provider.of<MapPageStore>(context);
     final imageLoader = Provider.of<ImageLoaderPhoto>(context, listen: false);
 
-    final pendingPhotos =
-        store.mapInfo!.spots[_spotId]!.photos.map((photo) async {
+    final pendingPhotos = spot!.photos.map((photo) async {
       var cacheFile = await imageLoader.loadImageWithCache(
           store.mapInfo!, photo.getFileName());
       return DraftPhoto.saved(photo, cachePath: cacheFile.path);
@@ -108,7 +112,7 @@ class SpotDetailPage extends StatelessWidget {
           transitionType: ContainerTransitionType.fadeThrough,
           transitionDuration: const Duration(milliseconds: 500),
           openBuilder: (context, closeContainer) {
-            var spotPhotos = store.mapInfo?.spots[_spotId]?.photos;
+            var spotPhotos = spot!.photos;
             return PhotoPreviewPage(
                 map: store.mapInfo!, photos: spotPhotos ?? [], index: index);
           },

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -16,21 +16,16 @@ import 'package:strollog/router/app_location.dart';
 import 'package:strollog/services/image_loader.dart';
 
 class SpotDetailPage extends StatelessWidget {
-  final String _spotId;
-  Spot? spot;
+  Spot spot;
 
-  SpotDetailPage(this._spotId, {Key? key})
-      : spot = null,
-        super(key: key);
+  SpotDetailPage(this.spot, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    var store = Provider.of<MapPageStore>(context);
-    spot = store.mapInfo!.spots[_spotId];
-
-    var title = spot!.title;
-    var comment = spot!.comment;
-    var date = spot!.date;
+    final mapPageStore = Provider.of<MapPageStore>(context);
+    var title = spot.title;
+    var comment = spot.comment;
+    var date = spot.date;
     final dateString = DateFormat('yyyy-MM-dd HH:mm').format(date);
 
     return Container(
@@ -55,7 +50,7 @@ class SpotDetailPage extends StatelessWidget {
           ]),
           Row(children: [
             const SizedBox(width: 100, child: Text('最終訪問日')),
-            _buildLastVisited(context, spot!),
+            _buildLastVisited(context, spot),
           ]),
           FutureBuilder<List<DraftPhoto>>(
             future: _loadImages(context),
@@ -73,7 +68,7 @@ class SpotDetailPage extends StatelessWidget {
                 onTap: () {
                   Provider.of<RouterState>(context, listen: false).pushRoute(
                       AppLocationSpotEdit(
-                          mapId: store.mapInfo!.id!, spotId: _spotId));
+                          mapId: mapPageStore.mapInfo!.id!, spotId: spot.id));
                 },
                 icon: const Icon(Icons.edit),
                 title: '編集'),
@@ -91,12 +86,12 @@ class SpotDetailPage extends StatelessWidget {
   }
 
   Future<List<DraftPhoto>> _loadImages(BuildContext context) async {
-    final store = Provider.of<MapPageStore>(context);
+    final mapPageStore = Provider.of<MapPageStore>(context);
     final imageLoader = Provider.of<ImageLoaderPhoto>(context, listen: false);
 
-    final pendingPhotos = spot!.photos.map((photo) async {
+    final pendingPhotos = spot.photos.map((photo) async {
       var cacheFile = await imageLoader.loadImageWithCache(
-          store.mapInfo!, photo.getFileName());
+          mapPageStore.mapInfo!, photo.getFileName());
       return DraftPhoto.saved(photo, cachePath: cacheFile.path);
     }).toList();
 
@@ -104,7 +99,7 @@ class SpotDetailPage extends StatelessWidget {
   }
 
   Widget _buildPhotoList(BuildContext context, List<DraftPhoto> draftPhotos) {
-    var store = Provider.of<MapPageStore>(context);
+    var mapPageStore = Provider.of<MapPageStore>(context);
     final List<Widget> photos = draftPhotos.asMap().entries.map((entry) {
       var index = entry.key;
       var draftPhoto = entry.value;
@@ -112,9 +107,9 @@ class SpotDetailPage extends StatelessWidget {
           transitionType: ContainerTransitionType.fadeThrough,
           transitionDuration: const Duration(milliseconds: 500),
           openBuilder: (context, closeContainer) {
-            var spotPhotos = spot!.photos;
+            var spotPhotos = spot.photos;
             return PhotoPreviewPage(
-                map: store.mapInfo!, photos: spotPhotos ?? [], index: index);
+                map: mapPageStore.mapInfo!, photos: spotPhotos, index: index);
           },
           closedElevation: 2.0,
           closedShape: RoundedRectangleBorder(

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -12,6 +12,7 @@ import 'package:strollog/domain/photo.dart';
 import 'package:strollog/lib/router/router_state.dart';
 import 'package:strollog/pages/map/map_page_store.dart';
 import 'package:strollog/pages/map/photo_preview_page.dart';
+import 'package:strollog/pages/map/spot_detail_page_store.dart';
 import 'package:strollog/router/app_location.dart';
 import 'package:strollog/services/image_loader.dart';
 
@@ -23,6 +24,10 @@ class SpotDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final mapPageStore = Provider.of<MapPageStore>(context);
+    final store = Provider.of<SpotDetailPageStore>(context);
+
+    store.init(mapPageStore.mapInfo!, spot);
+
     var title = spot.title;
     var comment = spot.comment;
     var date = spot.date;
@@ -156,8 +161,9 @@ class SpotDetailPage extends StatelessWidget {
   }
 
   Widget _buildLastVisited(BuildContext context, Spot spot) {
+    var store = Provider.of<SpotDetailPageStore>(context);
     var dateString = spot.lastVisited != null
-        ? DateFormat('yyyy-MM-DD HH:mm').format(spot.lastVisited!)
+        ? DateFormat('yyyy-MM-dd HH:mm').format(spot.lastVisited!)
         : '未設定';
 
     return InkWell(
@@ -168,12 +174,13 @@ class SpotDetailPage extends StatelessWidget {
               const Icon(Icons.update, size: 32),
             ])),
         onTap: () async {
-          await DateTimePicker.show(
+          var date = await DateTimePicker.show(
             context,
             initialDate: spot.lastVisited ?? DateTime.now(),
             firstDate: DateTime(2000, 1, 1),
             lastDate: DateTime.now(),
           );
+          store.setLastVisited(date);
         });
   }
 }

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -22,6 +22,7 @@ class SpotDetailPage extends StatelessWidget {
   Widget build(BuildContext context) {
     var store = Provider.of<MapPageStore>(context);
     var title = store.mapInfo!.spots[_spotId]!.title;
+    var comment = store.mapInfo!.spots[_spotId]!.comment;
     var date = store.mapInfo!.spots[_spotId]!.date;
     final dateString = DateFormat('yyyy-MM-dd HH:mm').format(date);
 
@@ -37,6 +38,10 @@ class SpotDetailPage extends StatelessWidget {
           Row(children: [
             const SizedBox(width: 100, child: Text('タイトル')),
             Text(title),
+          ]),
+          Row(children: [
+            const SizedBox(width: 100, child: Text('コメント')),
+            Text(comment),
           ]),
           FutureBuilder<List<DraftPhoto>>(
             future: _loadImages(context),

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -10,7 +10,6 @@ import 'package:strollog/domain/photo.dart';
 import 'package:strollog/lib/router/router_state.dart';
 import 'package:strollog/pages/map/map_page_store.dart';
 import 'package:strollog/pages/map/photo_preview_page.dart';
-import 'package:strollog/pages/map/spot_edit_page_store.dart';
 import 'package:strollog/router/app_location.dart';
 import 'package:strollog/services/image_loader.dart';
 
@@ -25,8 +24,6 @@ class SpotDetailPage extends StatelessWidget {
     var title = store.mapInfo!.spots[_spotId]!.title;
     var date = store.mapInfo!.spots[_spotId]!.date;
     final dateString = DateFormat('yyyy-MM-dd HH:mm').format(date);
-
-    var editFormStore = Provider.of<SpotEditPageStore>(context, listen: false);
 
     return Container(
       padding: const EdgeInsets.all(10),

--- a/lib/pages/map/spot_detail_page.dart
+++ b/lib/pages/map/spot_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:strollog/components/date_time_picker.dart';
 import 'package:strollog/components/image_thumbnail.dart';
 import 'package:strollog/components/ws_button.dart';
 import 'package:strollog/domain/map_info.dart';
@@ -164,6 +165,13 @@ class SpotDetailPage extends StatelessWidget {
               Text(dateString),
               const Icon(Icons.update, size: 32),
             ])),
-        onTap: () {});
+        onTap: () async {
+          await DateTimePicker.show(
+            context,
+            initialDate: spot.lastVisited ?? DateTime.now(),
+            firstDate: DateTime(2000, 1, 1),
+            lastDate: DateTime.now(),
+          );
+        });
   }
 }

--- a/lib/pages/map/spot_detail_page_store.dart
+++ b/lib/pages/map/spot_detail_page_store.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/cupertino.dart';
+import 'package:strollog/domain/map_info.dart';
+import 'package:strollog/repositories/map_info_repository.dart';
+
+class SpotDetailPageStore with ChangeNotifier {
+  final MapInfoRepository mapInfoRepository;
+  late MapInfo mapInfo;
+  late Spot spot;
+
+  SpotDetailPageStore(this.mapInfoRepository);
+
+  void init(MapInfo mapInfo, Spot spot) {
+    this.mapInfo = mapInfo;
+    this.spot = spot;
+  }
+
+  Future<void> setLastVisited(DateTime? date) async {
+    if (date == null) {
+      return;
+    }
+    spot.lastVisited = date;
+    await mapInfoRepository.updateLastVisited(mapInfo, spot.id, date);
+    notifyListeners();
+  }
+}

--- a/lib/repositories/map_info_repository.dart
+++ b/lib/repositories/map_info_repository.dart
@@ -146,7 +146,8 @@ class MapInfoRepository {
               .doc(map.id)
               .collection('photos')
               .doc(photo.key))
-          .toList()
+          .toList(),
+      'last_visited': spot.lastVisited,
     };
   }
 
@@ -174,7 +175,8 @@ class MapInfoRepository {
         newDate: data['date'].toDate(),
         score: data['score'] + .0,
         userNameInfo: userNameInfo,
-        photos: photos);
+        photos: photos,
+        lastVisited: data['last_visited']);
     return spot;
   }
 

--- a/lib/repositories/map_info_repository.dart
+++ b/lib/repositories/map_info_repository.dart
@@ -132,6 +132,19 @@ class MapInfoRepository {
         .set(_makeSpotJson(map, spot, spot.userNameInfo?.id));
   }
 
+  Future<void> updateLastVisited(
+      MapInfo map, String spotId, DateTime? date) async {
+//    map.spots[spotId]!.lastVisited = date;
+    await _firestore
+        .collection('maps')
+        .doc(map.id)
+        .collection('spots')
+        .doc(spotId)
+        .update({
+      'last_visited': date,
+    });
+  }
+
   Map<String, dynamic> _makeSpotJson(MapInfo map, Spot spot, String? uid) {
     return {
       'title': spot.title,
@@ -176,7 +189,7 @@ class MapInfoRepository {
         score: data['score'] + .0,
         userNameInfo: userNameInfo,
         photos: photos,
-        lastVisited: data['last_visited']);
+        lastVisited: data['last_visited']?.toDate());
     return spot;
   }
 


### PR DESCRIPTION
## チケット
- #47 

## やったこと
- スポットに最終訪問日を追加
- 詳細画面に日付を表示。日付をタップすると最終訪問日を入力するダイアログを表示
- 日付を更新できるようにする

## やってないこと
- 訪問から時間が経ったスポットの色を薄く表示 (別PRで対応)

## UI before / after
![ws-cast](https://user-images.githubusercontent.com/3823428/187043220-2af19f5b-2c78-471a-93c2-3221aadd71f9.gif)

## 補足
