### PR TITLE
名前をフィルター出来るように対応(1)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -140,6 +140,7 @@ class _ApplicationState extends State<Application> {
             create: (_context) => SpotEditPageStore(
                   Provider.of<MapInfoRepository>(_context, listen: false),
                   Provider.of<PhotoRepository>(_context, listen: false),
+                  Provider.of<NameRepository>(_context, listen: false),
                   Provider.of<AuthService>(_context, listen: false),
                   Provider.of<ImageLoaderPhoto>(_context, listen: false),
                 )),

--- a/lib/pages/map/spot_edit_page.dart
+++ b/lib/pages/map/spot_edit_page.dart
@@ -14,6 +14,7 @@ import 'package:strollog/lib/router/router_state.dart';
 import 'package:strollog/pages/app_page.dart';
 import 'package:strollog/pages/app_store.dart';
 import 'package:strollog/pages/map/spot_edit_page_store.dart';
+import 'package:strollog/pages/name_management/name_edit_page_store.dart';
 import 'package:strollog/repositories/name_repository.dart';
 import 'package:strollog/services/image_loader.dart';
 
@@ -251,47 +252,52 @@ class NameList extends StatefulWidget {
 }
 
 class NameListState extends State<NameList> {
-  List<Name>? nameList;
   String? selectedNameId;
 
   @override
   void initState() {
     super.initState();
     selectedNameId = widget.draftPhoto.name?.id;
-    Provider.of<NameRepository>(context, listen: false)
-        .fetchNames(widget.mapInfo.id!)
-        .then((value) => setState(() => nameList = value));
   }
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    var store = Provider.of<SpotEditPageStore>(context);
+    return Container(
+        child: Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
         const Text('名前を選択'),
-        SizedBox(
-            height: 300,
+        TextField(
+          decoration: const InputDecoration(hintText: 'よみを入力'),
+          onChanged: (text) {
+            store.updateNameFilter(text);
+          },
+        ),
+        Expanded(
             child: ListView(
-              children: nameList?.map((name) {
-                    return ListTile(
-                      title: Text(name.name),
-                      selected: selectedNameId == name.id,
-                      onTap: () {
-                        setState(() => selectedNameId = name.id);
-                      },
-                      leading: _buildFacePhoto(name),
-                    );
-                  }).toList() ??
-                  [],
-            )),
+          children: store.getFilteredNames().map((name) {
+            return ListTile(
+              title: Text(name.name),
+              selected: selectedNameId == name.id,
+              onTap: () {
+                setState(() => selectedNameId = name.id);
+              },
+              leading: _buildFacePhoto(name),
+            );
+          }).toList(),
+        )),
         Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
           WSButton(
             title: '決定',
             icon: const Icon(Icons.check),
             onTap: () {
-              Navigator.pop(context,
-                  nameList!.firstWhere((name) => name.id == selectedNameId));
+              Navigator.pop(
+                  context,
+                  store
+                      .getFilteredNames()
+                      .firstWhere((name) => name.id == selectedNameId));
             },
           ),
           WSButton(
@@ -303,7 +309,7 @@ class NameListState extends State<NameList> {
           ),
         ]),
       ],
-    );
+    ));
   }
 
   Widget _buildFacePhoto(Name name) {

--- a/lib/theme/light_theme_builder.dart
+++ b/lib/theme/light_theme_builder.dart
@@ -10,9 +10,12 @@ class LightThemeBuilder {
         space: 10,
         thickness: 10,
       ),
+      inputDecorationTheme: base.inputDecorationTheme
+          .copyWith(hintStyle: const TextStyle(color: Colors.black45)),
       textTheme: base.textTheme.copyWith(
-          // フォーム見出し
-          labelMedium: TextStyle(fontSize: 14, color: Colors.grey.shade600)),
+        // フォーム見出し
+        labelMedium: TextStyle(fontSize: 14, color: Colors.grey.shade600),
+      ),
       selectedRowColor: Colors.blue.shade200,
       listTileTheme: base.listTileTheme.copyWith(
           selectedTileColor: Colors.lightBlue.shade50,


### PR DESCRIPTION
## チケット
- #53 

## 対応内容・対応背景・妥協点

## やったこと
- 名前選択時、テキストボックスに入力した「読み」に合致する名前が一覧表示されるように対応

## やってないこと
- 名前登録画面への同機能の追加
- 名前編集画面のテストの実装

## UI before / after

https://user-images.githubusercontent.com/3823428/188099176-eb073900-9ab3-4410-b82d-c088cad3b017.mp4

## 補足
